### PR TITLE
Allow mixed type for fact name

### DIFF
--- a/src/Handler/MicrosoftTeamsRecord.php
+++ b/src/Handler/MicrosoftTeamsRecord.php
@@ -216,13 +216,16 @@ class MicrosoftTeamsRecord {
     }
 
     /**
-     * @param string $name
+     * @param mixed $name
      * @param mixed $value
      * @param bool $isQuoted
      * @return array
      */
-    public function getFact(string $name, $value, bool $isQuoted = false): array
+    public function getFact($name, $value, bool $isQuoted = false): array
     {
+        if (!is_string($name)) {
+            $name = strval($name);
+        }
         $name = trim(str_replace('_', ' ', $name));
         $value = $this->transformValue($value);
         return [

--- a/src/Handler/MicrosoftTeamsRecord.php
+++ b/src/Handler/MicrosoftTeamsRecord.php
@@ -221,7 +221,7 @@ class MicrosoftTeamsRecord {
      * @param bool $isQuoted
      * @return array
      */
-    public function getFact(string|int $name, $value, bool $isQuoted = false): array
+    public function getFact($name, $value, bool $isQuoted = false): array
     {
         if (is_int($name)) {
             $name = strval($name);

--- a/src/Handler/MicrosoftTeamsRecord.php
+++ b/src/Handler/MicrosoftTeamsRecord.php
@@ -216,14 +216,14 @@ class MicrosoftTeamsRecord {
     }
 
     /**
-     * @param mixed $name
+     * @param string|int $name
      * @param mixed $value
      * @param bool $isQuoted
      * @return array
      */
-    public function getFact($name, $value, bool $isQuoted = false): array
+    public function getFact(string|int $name, $value, bool $isQuoted = false): array
     {
-        if (!is_string($name)) {
+        if (is_int($name)) {
             $name = strval($name);
         }
         $name = trim(str_replace('_', ' ', $name));


### PR DESCRIPTION
Hey @actived 👋

Nice package. I love how easy it is to integrate!

What do you think about not constraining the type of the fact name? At least in my app, I do not always want to logg associative arrays. For example:

```php
$bar = [1, 2, 3];
logs()->error('foo', [$bar]);
```